### PR TITLE
CMakeLists: do not use --allow-multiple-definition on Apple

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -145,8 +145,10 @@ ELSE ()
   set (CMAKE_Fortran_FLAGS_DEBUG   "-O0 -g")
 ENDIF ()
 
-SET(CMAKE_MODULE_LINKER_FLAGS "${CMAKE_MODULE_LINKER_FLAGS} -Wl,--allow-multiple-definition")
-SET(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,--allow-multiple-definition")
+IF (NOT APPLE)
+  SET(CMAKE_MODULE_LINKER_FLAGS "${CMAKE_MODULE_LINKER_FLAGS} -Wl,--allow-multiple-definition")
+  SET(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,--allow-multiple-definition")
+ENDIF ()
 
 message (STATUS "CMAKE_Fortran_COMPILER full path: " ${CMAKE_Fortran_COMPILER})
 message (STATUS "CMAKE_Fortran_FLAGS: " ${CMAKE_Fortran_FLAGS})


### PR DESCRIPTION
Signed-off-by: Sergey Fedorov <vital.had@gmail.com>

Removing the flag (for macOS), build succeeds and all tests pass:
```
--->  Testing ForEx
Executing:  cd "/opt/local/var/macports/build/_opt_PPCRosettaPorts_fortran_ForEx/ForEx/work/build" && /usr/bin/make test 
Running tests...
/opt/local/bin/ctest --force-new-ctest-process 
Test project /opt/local/var/macports/build/_opt_PPCRosettaPorts_fortran_ForEx/ForEx/work/build
    Start 1: ExceptionContextStackNode_test_TEST
1/6 Test #1: ExceptionContextStackNode_test_TEST ...   Passed    0.02 sec
    Start 2: ExceptionContextStack_test_TEST
2/6 Test #2: ExceptionContextStack_test_TEST .......   Passed    0.02 sec
    Start 3: ExceptionHandler_test_TEST
3/6 Test #3: ExceptionHandler_test_TEST ............   Passed    0.03 sec
    Start 4: ExceptionStackNode_test_TEST
4/6 Test #4: ExceptionStackNode_test_TEST ..........   Passed    0.02 sec
    Start 5: ExceptionStack_test_TEST
5/6 Test #5: ExceptionStack_test_TEST ..............   Passed    0.02 sec
    Start 6: Exception_test_TEST
6/6 Test #6: Exception_test_TEST ...................   Passed    0.02 sec

100% tests passed, 0 tests failed out of 6

Total Test time (real) =   0.17 sec
```